### PR TITLE
Fix the Publish Docs workflow

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -134,6 +134,11 @@ jobs:
         shell: bash -l {0}
 
     steps:
+      - name: Set env vars
+        run: |
+          export REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}  # just the repo, as opposed to org/repo
+          echo "REPOSITORY_NAME=${REPOSITORY_NAME}" >> $GITHUB_ENV
+
       - name: Download docs from GitHub artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -118,13 +118,33 @@ jobs:
           path: docs/build/html/
 
   publish-docs:
-    name: Deploy
-    uses: peaceiris/actions-gh-pages@v4
-    with:
-      github_token: ${{ secrets.GITHUB_TOKEN }}
-      publish_dir: ./public
-      path: docs/build/html/        
+    name: Deploy docs
+    runs-on: ${{ matrix.host-os }}
+    needs: lint
 
+    strategy:
+      matrix:
+        # host-os: ["ubuntu-latest", "macos-13", "macos-14"]
+        host-os: ["ubuntu-latest"]
+        python-version: ["3.12"]
+      fail-fast: false
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Download docs from GitHub artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.REPOSITORY_NAME }}-${{ matrix.python-version }}-${{ matrix.host-os }}-docs
+          path: docs/build/html/
+
+      - name: Deploy docs to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/build/html/
 
   # publish-docs:
   #   if: github.repository_owner == 'NSLS-II' && github.ref == 'refs/heads/master'

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -151,42 +151,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/build/html/
 
-  # publish-docs:
-  #   if: github.repository_owner == 'NSLS-II' && github.ref == 'refs/heads/master'
-  #   name: Publish docs
-  #   needs: test
-  #   runs-on: ${{ matrix.host-os }}
-  #   strategy:
-  #     matrix:
-  #       python-version: ["3.10"]
-  #       host-os: ["ubuntu-latest"]
-  #     fail-fast: false
-
-  #   steps:
-  #     - name: Set env vars
-  #       run: |
-  #         export REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}  # just the repo, as opposed to org/repo
-  #         echo "REPOSITORY_NAME=${REPOSITORY_NAME}" >> $GITHUB_ENV
-
-  #     - name: Download docs from GitHub artifacts
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: ${{ env.REPOSITORY_NAME }}-${{ matrix.python-version }}-${{ matrix.host-os }}-docs
-  #         path: docs/build/html/
-
-  #     - name: Deploy documentation to edrixs.github.io
-  #       # We pin to the SHA, not the tag, for security reasons.
-  #       # https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
-  #       uses: peaceiris/actions-gh-pages@bbdfb200618d235585ad98e965f4aafc39b4c501  # v3.7.3
-  #       with:
-  #         deploy_key: ${{ secrets.ACTIONS_DOCUMENTATION_DEPLOY_KEY }}
-  #         publish_branch: master
-  #         publish_dir: ./docs/build/html
-  #         external_repository: EDRIXS/EDRIXS.github.io
-  #         destination_dir: ${{ env.REPOSITORY_NAME }}  # just the repo name, without the "NSLS-II/"
-  #         keep_files: true  # Keep old files.
-  #         force_orphan: false  # Keep git history.
-
   publish-to-pypi:
     # Hints from:
     #   - https://github.com/pypa/gh-action-pypi-publish/discussions/28

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -148,7 +148,6 @@ jobs:
       - name: Deploy docs to gh-pages
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/build/html/
 
   # publish-docs:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -120,7 +120,7 @@ jobs:
   publish-docs:
     name: Deploy docs
     runs-on: ${{ matrix.host-os }}
-    needs: lint
+    needs: test
 
     strategy:
       matrix:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -97,9 +97,9 @@ jobs:
       #     set -vxeuo pipefail
       #     delocate-wheelpython -v ./dist/${{ env.REPOSITORY_NAME }}-*-cp${PYTHON_VERSION_NODOT}*.whl
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.REPOSITORY_NAME }}-wheels
+          name: ${{ env.REPOSITORY_NAME }}-${{ matrix.python-version }}-${{ matrix.host-os }}-wheel
           path: dist/*
 
       - name: Test with pytest
@@ -192,6 +192,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+    strategy:
+      matrix:
+        # host-os: ["ubuntu-latest", "macos-13", "macos-14"]
+        host-os: ["ubuntu-latest"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+      fail-fast: false
 
     steps:
       - name: Set env vars
@@ -202,9 +208,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download wheels from GitHub artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: ${{ env.REPOSITORY_NAME }}-wheels
+          name: ${{ env.REPOSITORY_NAME }}-${{ matrix.python-version }}-${{ matrix.host-os }}-wheel
           path: dist/
 
       - name: Publish wheels to PyPI

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -118,6 +118,7 @@ jobs:
           path: docs/build/html/
 
   publish-docs:
+    if: github.repository_owner == 'EDRIXS' && github.ref == 'refs/heads/master'
     name: Deploy docs
     runs-on: ${{ matrix.host-os }}
     needs: test

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -148,6 +148,7 @@ jobs:
       - name: Deploy docs to gh-pages
         uses: peaceiris/actions-gh-pages@v4
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/build/html/
 
   # publish-docs:


### PR DESCRIPTION
# Description

Looks like this PR fixes the docs:
https://edrixs.github.io/edrixs/user/index.html
![image](https://github.com/user-attachments/assets/35931264-009d-453f-a892-bd4fd2e6b456)

# Example run of the workflow

https://github.com/EDRIXS/edrixs/actions/runs/13580361064

# Updates after testing

In my tests, I did not restrict the branches during my tests, so that I could test the publishing workflow. I've added a commit - 3fe1339 - to restrict it.

# Acknowledgements:
- https://github.com/peaceiris/actions-gh-pages?tab=readme-ov-file#supported-tokens
- https://github.com/peaceiris/actions-gh-pages/issues/1102#issuecomment-2402751676 - this hint helped to resolve the permissions issue.