### PR TITLE
remove combinations

### DIFF
--- a/edrixs/fock_basis.py
+++ b/edrixs/fock_basis.py
@@ -1,60 +1,12 @@
 #!/usr/bin/env python
 
-__all__ = ['combination', 'fock_bin', 'get_fock_bin_by_N', 'get_fock_half_N',
+__all__ = ['fock_bin', 'get_fock_bin_by_N', 'get_fock_half_N',
            'get_fock_full_N', 'get_fock_basis_by_NLz', 'get_fock_basis_by_NSz',
            'get_fock_basis_by_NJz', 'get_fock_basis_by_N_abelian',
            'get_fock_basis_by_N_LzSz', 'write_fock_dec_by_N']
 
 import numpy as np
 import itertools
-
-
-def combination(n, m):
-    """
-    Calculate the combination :math:`C_{n}^{m}`,
-
-    .. math::
-
-        C_{n}^{m} = \\frac{n!}{m!(n-m)!}.
-
-    Parameters
-    ----------
-    n: int
-       Number n.
-    m: int
-        Number m.
-
-    Returns
-    -------
-    res: int
-        The calculated result.
-
-    Examples
-    --------
-    >>> import edrixs
-    >>> edrixs.combination(6, 2)
-    15
-
-    """
-
-    if m > n or n < 0 or m < 0:
-        print("wrong number in combination")
-        return
-    if m == 0 or n == m:
-        return 1
-
-    largest = max(m, n - m)
-    smallest = min(m, n - m)
-    numer = 1.0
-    for i in range(largest + 1, n + 1):
-        numer *= i
-
-    denom = 1.0
-    for i in range(1, smallest + 1):
-        denom *= i
-
-    res = int(numer / denom)
-    return res
 
 
 def fock_bin(n, k):

--- a/examples/sphinx/example_0_ed_calculator.py
+++ b/examples/sphinx/example_0_ed_calculator.py
@@ -11,6 +11,7 @@ coupling.
 ################################################################################
 # Import the necessary modules.
 import numpy as np
+from math import comb
 import matplotlib.pyplot as plt
 import scipy
 import edrixs
@@ -52,7 +53,7 @@ print(np.array(basis))
 # with two spins per orbital).
 message = ("We predict C(norb={}, noccu={})={:.0f} states and we got {:d}, "
            "which is reassuring!")
-print(message.format(norb, noccu, edrixs.combination(norb, noccu), len(basis)))
+print(message.format(norb, noccu, comb(norb, noccu), len(basis)))
 ################################################################################
 # Note that in more complicated problems with both valence and core
 # electrons, the edrixs convention is to list the valence electrons first.


### PR DESCRIPTION
The function `edrixs.fock_basis.combination` seems unneccesary, because since python 3.8 this has been available as a builtin via `math.comb`. #232 