### PR TITLE
remove outdated pkg_resources

### DIFF
--- a/edrixs/tests/test_utils.py
+++ b/edrixs/tests/test_utils.py
@@ -92,3 +92,14 @@ def test_CT_imp_bath_core_hole():
     assert E_dc_val == E_dc_cal
     assert E_Lc_val == E_Lc_cal
     assert E_p_val == E_p_cal
+
+
+def test_get_atom_data():
+    res = edrixs.get_atom_data('Ni', v_name='3d', v_noccu=8)
+    slater_i = res['slater_i']
+    assert slater_i[0][0] == 'F0_11'
+    assert slater_i[0][1] == 0.0
+    assert slater_i[1][0] == 'F2_11'
+    assert slater_i[1][1] == 12.234
+    assert slater_i[2][0] == 'F4_11'
+    assert slater_i[2][1] == 7.598

--- a/edrixs/utils.py
+++ b/edrixs/utils.py
@@ -7,7 +7,7 @@ __all__ = ['beta_to_kelvin', 'kelvin_to_beta', 'boltz_dist', 'UJ_to_UdJH',
 
 import numpy as np
 import json
-import pkg_resources
+from importlib import resources
 
 
 def beta_to_kelvin(beta):
@@ -835,8 +835,9 @@ def get_atom_data(atom, v_name, v_noccu, edge=None, trans_to_which=1, label=None
         if ishell not in avail_shells:
             raise Exception("Not available for this shell: ", ishell)
 
-    fname = pkg_resources.resource_filename('edrixs', 'atom_data/'+atom+'.json')
-    with open(fname, 'r') as f:
+    data_pkg = 'edrixs.atom_data'
+    fname = f'{atom}.json'
+    with resources.open_text(data_pkg, fname) as f:
         atom_dict = json.load(f)
 
     res = {}


### PR DESCRIPTION
Test raised a warning with pkg_resources. This resolves the warning by updating to a more modern package. 