### PR TITLE
fix warning

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -109,7 +109,6 @@ todo_include_todos = False
 #
 html_theme = 'sphinx_rtd_theme'
 import sphinx_rtd_theme
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Docs build had a warning associated with the line
```
html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
```

the issue is fixed by removing it. 