### PR TITLE
models/ops legacy compatibility

### DIFF
--- a/edrixs/models.py
+++ b/edrixs/models.py
@@ -87,7 +87,9 @@ def model_1v1c(shell_name, *, shell_level=None, v_soc=None, c_soc=0,
     c_norb = info_shell[c_name][1]
     ntot = v_norb + c_norb
 
-    emat_i = np.zeros((ntot, ntot), dtype=complex)
+    # Match the legacy Fortran initial Hilbert space: the core shell is not an
+    # explicit degree of freedom before the x-ray transition.
+    emat_i = np.zeros((v_norb, v_norb), dtype=complex)
     emat_n = np.zeros((ntot, ntot), dtype=complex)
 
     # Coulomb interaction.
@@ -119,7 +121,12 @@ def model_1v1c(shell_name, *, shell_level=None, v_soc=None, c_soc=0,
     print()
 
     case = v_name + c_name
-    umat_i = get_umat_slater(case, *slater_i)
+    umat_i_full = get_umat_slater(case, *slater_i)
+    # Legacy Fortran accepts initial core-related Slater integrals but they are
+    # ineffective because fock_i contains valence orbitals only.
+    umat_i = umat_i_full[
+        0:v_norb, 0:v_norb, 0:v_norb, 0:v_norb
+    ]
     umat_n = get_umat_slater(case, *slater_n)
 
     if verbose > 0:
@@ -151,8 +158,9 @@ def model_1v1c(shell_name, *, shell_level=None, v_soc=None, c_soc=0,
 
     # Shell levels.
     if shell_level is not None:
+        eval_shift = shell_level[1] * c_norb / v_noccu
         emat_i[0:v_norb, 0:v_norb] += np.eye(v_norb) * shell_level[0]
-        emat_i[v_norb:ntot, v_norb:ntot] += np.eye(c_norb) * shell_level[1]
+        emat_i[0:v_norb, 0:v_norb] += np.eye(v_norb) * eval_shift
 
         emat_n[0:v_norb, 0:v_norb] += np.eye(v_norb) * shell_level[0]
         emat_n[v_norb:ntot, v_norb:ntot] += np.eye(c_norb) * shell_level[1]
@@ -188,7 +196,7 @@ def model_1v1c(shell_name, *, shell_level=None, v_soc=None, c_soc=0,
         write_emat(emat_n, 'hopping_n.in')
 
     # Fock-basis metadata.
-    basis_i = FockBasisSpec.from_args(v_norb, v_noccu, c_norb, c_norb)
+    basis_i = FockBasisSpec.from_args(v_norb, v_noccu)
     basis_n = FockBasisSpec.from_args(v_norb, v_noccu + 1, c_norb, c_norb - 1)
 
     print("edrixs >>> Dimension of the initial Hamiltonian: ", len(basis_i))
@@ -250,8 +258,7 @@ def model_2v1c(
     Returns
     -------
     emat_i, umat_i, basis_i, emat_n, umat_n, basis_n, trans_mat
-        These can be passed directly to ``get_ops`` with the SciPy, dense,
-        or PETSc backend.
+        These can be passed directly to ``get_ops`` with the SciPy or dense backend.
     """
     print("edrixs >>> Setting up 2v1c problem ...")
 
@@ -313,9 +320,13 @@ def model_2v1c(
         ))
     print()
 
-    umat_i = get_umat_slater_3shells(
+    umat_i_full = get_umat_slater_3shells(
         (v1_name, v2_name, c_name), *slater_i
     )
+    umat_i = umat_i_full[
+        0:v1v2_norb, 0:v1v2_norb,
+        0:v1v2_norb, 0:v1v2_norb
+    ]
     umat_n = get_umat_slater_3shells(
         (v1_name, v2_name, c_name), *slater_n
     )
@@ -328,7 +339,7 @@ def model_2v1c(
         umat_i = _umat_dense_to_sparse(umat_i, tol=tol)
         umat_n = _umat_dense_to_sparse(umat_n, tol=tol)
 
-    emat_i = np.zeros((ntot, ntot), dtype=complex)
+    emat_i = np.zeros((v1v2_norb, v1v2_norb), dtype=complex)
     emat_n = np.zeros((ntot, ntot), dtype=complex)
 
     # Spin-orbit coupling.
@@ -375,22 +386,25 @@ def model_2v1c(
             v2_othermat
         )
 
-    # Shell levels.  Since the setup/get_ops route keeps the core orbitals in the
-    # Fock basis, the filled core contribution is represented explicitly.
+    # Shell levels.  Match the legacy Fortran convention: the filled core is
+    # absent from the initial basis and its one-body energy is redistributed
+    # uniformly over the fixed-total-occupancy valence sector.
     if shell_level is not None:
+        eval_shift = shell_level[2] * c_norb / v_tot_noccu
         emat_i[0:v1_norb, 0:v1_norb] += np.eye(v1_norb) * shell_level[0]
+        emat_i[0:v1_norb, 0:v1_norb] += np.eye(v1_norb) * eval_shift
         emat_n[0:v1_norb, 0:v1_norb] += np.eye(v1_norb) * shell_level[0]
 
         emat_i[v1_norb:v1v2_norb, v1_norb:v1v2_norb] += (
             np.eye(v2_norb) * shell_level[1]
         )
+        emat_i[v1_norb:v1v2_norb, v1_norb:v1v2_norb] += (
+            np.eye(v2_norb) * eval_shift
+        )
         emat_n[v1_norb:v1v2_norb, v1_norb:v1v2_norb] += (
             np.eye(v2_norb) * shell_level[1]
         )
 
-        emat_i[v1v2_norb:ntot, v1v2_norb:ntot] += (
-            np.eye(c_norb) * shell_level[2]
-        )
         emat_n[v1v2_norb:ntot, v1v2_norb:ntot] += (
             np.eye(c_norb) * shell_level[2]
         )
@@ -427,9 +441,7 @@ def model_2v1c(
         write_emat(emat_i, 'hopping_i.in')
         write_emat(emat_n, 'hopping_n.in')
 
-    basis_i = FockBasisSpec.from_args(
-        v1v2_norb, v_tot_noccu, c_norb, c_norb
-    )
+    basis_i = FockBasisSpec.from_args(v1v2_norb, v_tot_noccu)
     basis_n = FockBasisSpec.from_args(
         v1v2_norb, v_tot_noccu + 1, c_norb, c_norb - 1
     )
@@ -474,8 +486,7 @@ def model_siam(
     Returns
     -------
     emat_i, umat_i, basis_i, emat_n, umat_n, basis_n, trans_mat
-        These can be passed directly to ``get_ops`` with the SciPy, dense,
-        or PETSc backend.
+        These can be passed directly to ``get_ops`` with the SciPy or dense backend.
     """
     print("edrixs >>> Setting up SIAM problem ...")
 
@@ -532,16 +543,22 @@ def model_siam(
     umat_tmp_i = get_umat_slater(v_name + c_name, *slater_i)
     umat_tmp_n = get_umat_slater(v_name + c_name, *slater_n)
 
+    # The legacy initial SIAM basis contains impurity+bath orbitals only.
+    # Consequently all initial Coulomb terms involving the core are ineffective.
+    umat_tmp_i = umat_tmp_i[
+        0:v_norb, 0:v_norb, 0:v_norb, 0:v_norb
+    ]
+
     if sparse_U:
         umat_i = _embed_impurity_core_umat_sparse(
-            umat_tmp_i, v_norb, c_norb, ntot_v, tol=tol
+            umat_tmp_i, v_norb, 0, ntot_v, tol=tol
         )
         umat_n = _embed_impurity_core_umat_sparse(
             umat_tmp_n, v_norb, c_norb, ntot_v, tol=tol
         )
     else:
         umat_i = _embed_impurity_core_umat(
-            umat_tmp_i, v_norb, c_norb, ntot_v
+            umat_tmp_i, v_norb, 0, ntot_v
         )
         umat_n = _embed_impurity_core_umat(
             umat_tmp_n, v_norb, c_norb, ntot_v
@@ -551,7 +568,7 @@ def model_siam(
         write_umat(umat_i, 'coulomb_i.in')
         write_umat(umat_n, 'coulomb_n.in')
 
-    emat_i = np.zeros((ntot, ntot), dtype=complex)
+    emat_i = np.zeros((ntot_v, ntot_v), dtype=complex)
     emat_n = np.zeros((ntot, ntot), dtype=complex)
 
     if siam_type == 1:
@@ -633,7 +650,7 @@ def model_siam(
             np.transpose(trans_c2n)
         )
 
-    emat_i[:, :] = cb_op(emat_i, tmat)
+    emat_i[:, :] = cb_op(emat_i, tmat[0:ntot_v, 0:ntot_v])
     emat_n[:, :] = cb_op(emat_n, tmat)
 
     if ext_B is not None:
@@ -641,16 +658,16 @@ def model_siam(
         emat_i[0:v_norb, 0:v_norb] += zeeman
         emat_n[0:v_norb, 0:v_norb] += zeeman
 
-    # Since the setup/get_ops route keeps the core orbitals in the Fock basis, the
-    # filled-core contribution is represented explicitly.
-    emat_i[ntot_v:ntot, ntot_v:ntot] += np.eye(c_norb) * c_level
+    # Match the fixed-N legacy Fortran convention for the omitted filled core.
+    eval_shift = c_level * c_norb / v_noccu
+    emat_i[0:ntot_v, 0:ntot_v] += np.eye(ntot_v) * eval_shift
     emat_n[ntot_v:ntot, ntot_v:ntot] += np.eye(c_norb) * c_level
 
     if verbose > 0:
         write_emat(emat_i, 'hopping_i.in')
         write_emat(emat_n, 'hopping_n.in')
 
-    basis_i = FockBasisSpec.from_args(ntot_v, v_noccu, c_norb, c_norb)
+    basis_i = FockBasisSpec.from_args(ntot_v, v_noccu)
     basis_n = FockBasisSpec.from_args(ntot_v, v_noccu + 1, c_norb, c_norb - 1)
 
     print("edrixs >>> Dimension of the initial Hamiltonian: ", len(basis_i))

--- a/edrixs/solvers.py
+++ b/edrixs/solvers.py
@@ -24,7 +24,9 @@ from .photon_transition import (
 )
 from .coulomb_utensor import get_umat_slater
 from .manybody_operator import two_fermion, four_fermion
-from .fock_basis import build_fock_basis, get_fock_bin_by_N, write_fock_dec_by_N
+from .fock_basis import (
+    FockBasisSpec, build_fock_basis, get_fock_bin_by_N, write_fock_dec_by_N
+)
 from .basis_transform import cb_op2, tmat_r2c, cb_op
 from .utils import info_atomic_shell, slater_integrals_name, boltz_dist
 from .rixs_utils import scattering_mat
@@ -32,7 +34,6 @@ from .plot_spectrum import get_spectra_from_poles, merge_pole_dicts
 from .soc import atom_hsoc
 from .petsc_backend import petsc_backend
 from .scipy_backend import scipy_backend
-from .fortran_backend import fortran_backend
 from ._solvers_helpers import (
     _ed_1or2_valence_1core,
     _infer_backend,
@@ -101,15 +102,10 @@ def build_op(emat, umat, lb, rb=None, *, backend='scipy',
             build_op_backend = scipy_backend.build_op_dense
         case 'petsc':
             build_op_backend = petsc_backend.build_op_petsc
-        case 'fortran':
-            raise ValueError(
-                "The Fortran backend writes a complete problem through get_ops; "
-                "build_op is not available for backend='fortran'"
-            )
         case _:
             raise ValueError(
                 "Unknown backend {!r}; expected 'scipy', 'dense', or "
-                "'petsc', or 'fortran'".format(backend)
+                "'petsc'".format(backend)
             )
 
     lb = build_fock_basis(lb, method=basis_method)
@@ -139,7 +135,7 @@ def get_ops(
     emat_i, umat_i, basis_i, emat_n, umat_n, basis_n, trans_mat
         Backend-neutral problem definition returned by :mod:`edrixs.models`
         model functions.
-    backend : {'scipy', 'dense', 'petsc', 'fortran'}, optional
+    backend : {'scipy', 'dense', 'petsc'}, optional
         Backend used for the returned operators. The default is ``'scipy'``.
     basis_method : {'combinadic', 'explicit'}, optional
         Basis representation constructed from the model metadata. The default
@@ -147,13 +143,8 @@ def get_ops(
     use_numba : bool, optional
         JIT-compile matrix-entry construction. The default is False.
     backend_kws : mapping, optional
-        Backend-specific operator-construction options. Solver calls for the
-        Fortran backend accept ``ed_executable``, ``xas_executable``, and
-        ``rixs_executable``. ``comm`` selects the parent mpi4py communicator.
-        With a multi-rank ``comm``, every rank must make each Fortran-backend
-        call collectively; rank zero spawns the standalone solver with the
-        parent communicator size. The MPI allocation must have enough spare
-        slots for those child processes (or permit oversubscription).
+        Backend-specific operator-construction options. For the SciPy and
+        dense compatibility backends this includes ``tol``.
 
     Returns
     -------
@@ -161,12 +152,6 @@ def get_ops(
         Initial/final Hamiltonian, intermediate Hamiltonian, and transition
         operators for the selected backend.
     """
-    if backend == 'fortran':
-        return fortran_backend.write_problem(
-            emat_i, umat_i, basis_i, emat_n, umat_n, basis_n, trans_mat,
-            backend_kws=backend_kws,
-        )
-
     basis_i = build_fock_basis(basis_i, method=basis_method)
     basis_n = build_fock_basis(basis_n, method=basis_method)
 
@@ -182,12 +167,36 @@ def get_ops(
     trans_mat = np.asarray(trans_mat)
     if trans_mat.ndim != 3:
         raise ValueError("trans_mat must be a three-dimensional array")
+
+    # model_* follows the legacy Fortran Hilbert-space convention: the initial
+    # basis contains valence orbitals only, whereas the transition operator is
+    # defined in the full valence+core orbital space.  For operator construction
+    # only, lift the initial basis by appending one completely filled core
+    # sector.  Its dimension is one, so this preserves the initial basis
+    # dimension and column ordering exactly.
+    trans_basis_i = basis_i
+    if basis_n.norbs > basis_i.norbs:
+        core_norb = basis_n.norbs - basis_i.norbs
+        if getattr(basis_i, 'spec', None) is None:
+            raise ValueError(
+                "cannot construct a valence-to-core transition from an "
+                "unstructured initial Fock basis"
+            )
+        lifted_spec = FockBasisSpec(
+            basis_i.spec.shapes + ((core_norb, core_norb),)
+        )
+        trans_basis_i = build_fock_basis(lifted_spec, method=basis_method)
+    elif basis_n.norbs < basis_i.norbs:
+        raise ValueError(
+            "intermediate basis cannot have fewer orbitals than initial basis"
+        )
+
     trans_ops = [
         build_op(
             component,
             None,
             basis_n,
-            basis_i,
+            trans_basis_i,
             backend=backend,
             use_numba=use_numba, backend_kws=backend_kws,
         )
@@ -224,12 +233,10 @@ def ed(hmat_i, num_evals=1, *, backend=None, backend_kws=None):
             ed_backend = scipy_backend.ed_dense
         case 'petsc':
             ed_backend = petsc_backend.ed_petsc
-        case 'fortran':
-            ed_backend = fortran_backend.ed_fortran
         case _:
             raise ValueError(
                 "Unknown backend {!r}; expected 'scipy', 'dense', or "
-                "'petsc', or 'fortran'".format(backend_name)
+                "'petsc'".format(backend_name)
             )
 
     return ed_backend(
@@ -261,12 +268,10 @@ def xas(eval_i, evec_i, hmat_n, trans_op, ominc, *,
             xas_backend = scipy_backend.xas_dense
         case 'petsc':
             xas_backend = petsc_backend.xas_petsc
-        case 'fortran':
-            xas_backend = fortran_backend.xas_fortran
         case _:
             raise ValueError(
                 "Unknown backend {!r}; expected 'scipy', 'dense', or "
-                "'petsc', or 'fortran'".format(backend_name)
+                "'petsc'".format(backend_name)
             )
 
     return xas_backend(
@@ -309,12 +314,10 @@ def rixs(eval_i, evec_i, hmat_i, hmat_n, trans_op, ominc, eloss, *,
             rixs_backend = scipy_backend.rixs_dense
         case 'petsc':
             rixs_backend = petsc_backend.rixs_petsc
-        case 'fortran':
-            rixs_backend = fortran_backend.rixs_fortran
         case _:
             raise ValueError(
                 "Unknown backend {!r}; expected 'scipy', 'dense', or "
-                "'petsc', or 'fortran'".format(backend_name)
+                "'petsc'".format(backend_name)
             )
 
     return rixs_backend(

--- a/tests/test_model_operator_routes.py
+++ b/tests/test_model_operator_routes.py
@@ -86,9 +86,9 @@ def test_all_model_functions_return_compact_basis_metadata():
     ]
 
     expected_shapes = [
-        (((6, 1), (2, 2)), ((6, 2), (2, 1))),
-        (((4, 1), (6, 6)), ((4, 2), (6, 5))),
-        (((4, 1), (6, 6)), ((4, 2), (6, 5))),
+        (((6, 1),), ((6, 2), (2, 1))),
+        (((4, 1),), ((4, 2), (6, 5))),
+        (((4, 1),), ((4, 2), (6, 5))),
     ]
 
     for problem, (initial_shapes, intermediate_shapes) in zip(problems, expected_shapes):


### PR DESCRIPTION
changed initial Hilbert space to omit the filled core shell